### PR TITLE
Stands out escaped characters for clarity

### DIFF
--- a/schemes/Material-Theme.tmTheme
+++ b/schemes/Material-Theme.tmTheme
@@ -405,7 +405,7 @@ meta.selector.css entity.other.attribute-name.class, source.scss entity.other.at
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#80cbc4</string>
+				<string>#e6647c</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
I wonder if we could add another color for escaped chararacters, since it stands out in Regular Expression and some other cases like this.

Though I'm not sure this would be the right color to use.

![2015-06-11 10 24 11](https://cloud.githubusercontent.com/assets/2749593/8098627/fc3b8306-1024-11e5-8fa2-bd291ddcfcfa.png)
