### PR TITLE
Support for dirty state w/show_tab_close_buttons

### DIFF
--- a/Material-Theme-Darker.sublime-theme
+++ b/Material-Theme-Darker.sublime-theme
@@ -345,7 +345,7 @@
 
 		{
 			"class": "tab_close_button",
-			"content_margin": [8, 8],
+			"content_margin": [0, 0],
 
 			 // Close Icon
 			"layer0.texture": "Material Theme/assets/commons/close_icon.png",
@@ -367,11 +367,8 @@
 			// Default
 		{
 			"class": "tab_close_button",
-			"settings": ["!show_tab_close_buttons"],
-			"layer0.opacity": 0, // Close Icon
-			"layer1.opacity": 0, // Close Icon
-			"layer2.opacity": 0, // Close Icon
-			"layer3.opacity": 0, // Close Icon
+			"settings": ["show_tab_close_buttons"],
+			"content_margin": [8,8],
 		},
 			// Selected Tab
 		{
@@ -396,7 +393,8 @@
 			"layer0.opacity": 0, // Close Icon
 			"layer1.opacity": 0, // Close Icon Hover
 			"layer2.opacity": 1, // Dirty Icon
-			"layer3.opacity": 0 // Dirty Icon
+			"layer3.opacity": 0, // Dirty Icon Hover
+			"content_margin": [8,8],
 		},
 			// Dirty tab on hover
 		{

--- a/Material-Theme.sublime-theme
+++ b/Material-Theme.sublime-theme
@@ -342,10 +342,9 @@
 		},
 
 			// Tab Close Buttons
-
 		{
 			"class": "tab_close_button",
-			"content_margin": [8, 8],
+			"content_margin": [0, 0],
 
 			 // Close Icon
 			"layer0.texture": "Material Theme/assets/commons/close_icon.png",
@@ -364,14 +363,12 @@
 			"layer3.texture": "Material Theme/assets/commons/dirty_icon--hover.png",
 			"layer3.opacity": { "target": 0.0, "speed": 5.0, "interpolation": "smoothstep" }
 		},
+
 			// Default
 		{
 			"class": "tab_close_button",
-			"settings": ["!show_tab_close_buttons"],
-			"layer0.opacity": 0, // Close Icon
-			"layer1.opacity": 0, // Close Icon
-			"layer2.opacity": 0, // Close Icon
-			"layer3.opacity": 0, // Close Icon
+			"settings": ["show_tab_close_buttons"],
+			"content_margin": [8,8],
 		},
 			// Selected Tab
 		{
@@ -396,8 +393,10 @@
 			"layer0.opacity": 0, // Close Icon
 			"layer1.opacity": 0, // Close Icon Hover
 			"layer2.opacity": 1, // Dirty Icon
-			"layer3.opacity": 0 // Dirty Icon
+			"layer3.opacity": 0, // Dirty Icon Hover
+			"content_margin": [8,8],
 		},
+
 			// Dirty tab on hover
 		{
 			"class": "tab_close_button",


### PR DESCRIPTION
This PR will fix an issue where invisible close buttons are still active on tabs that are new or not dirty when using `show_tab_close_buttons: false`.

annoyingly it seems the dirty indicator has to function like a close button, but at least the close button will warn you if you accidentally try to close a dirty file.