### PR TITLE
Enable better highlighting of active indent

### DIFF
--- a/schemes/Material-Theme.tmTheme
+++ b/schemes/Material-Theme.tmTheme
@@ -30,12 +30,12 @@
 				<string>#80CBC420</string>
 				<key>selectionForeground</key>
 				<string>#FFFFFF</string>
-				<key>guide</key>
-				<string>#65737e</string>
+        			<key>guide</key>
+				<string>#37474F80</string>
 				<key>activeGuide</key>
-				<string>#F8E71C</string>
+				<string>#80CBC470</string>
 				<key>stackGuide</key>
-        			<string>#65737e</string>
+				<string>#37474Fff</string>
 				<key>gutterForeground</key>
 				<string>#37474F</string>
 				<key>findHighlight</key>

--- a/schemes/Material-Theme.tmTheme
+++ b/schemes/Material-Theme.tmTheme
@@ -31,9 +31,11 @@
 				<key>selectionForeground</key>
 				<string>#FFFFFF</string>
 				<key>guide</key>
-				<string>#37474F80</string>
+				<string>#65737e</string>
 				<key>activeGuide</key>
-				<string>#80CBC450</string>
+				<string>#F8E71C</string>
+				<key>stackGuide</key>
+        			<string>#65737e</string>
 				<key>gutterForeground</key>
 				<string>#37474F</string>
 				<key>findHighlight</key>


### PR DESCRIPTION
This will turn on highlighting of the active indentation guide as well as the stacked, or parent, indentation guides.


	"indent_guide_options":
	[
		"draw_normal",
		"draw_active"
	],

Reference 
http://wesbos.com/sublime-text-indentation-guide-lines/