### PR TITLE
Highlight sidebar folder on select with keyboard.

### DIFF
--- a/Material-Theme.sublime-theme
+++ b/Material-Theme.sublime-theme
@@ -560,6 +560,12 @@
 
 		{
 			"class": "sidebar_label",
+			"parents": [{"class": "tree_row", "attributes": ["expandable", "selected"]}],
+			"color": [255, 255, 255]
+		},
+
+		{
+			"class": "sidebar_label",
 			"parents": [{"class": "tree_row", "attributes": ["expanded"]}],
 			"settings": ["bold_folder_labels"],
 			"font.bold": true,
@@ -570,6 +576,12 @@
 			"class": "sidebar_label",
 			"parents": [{"class": "tree_row", "attributes": ["expanded"]}],
 			"color": [128, 203, 196]
+		},
+
+		{
+			"class": "sidebar_label",
+			"parents": [{"class": "tree_row", "attributes": ["expanded", "selected"]}],
+			"color": [255, 255, 255]
 		},
 
 		{
@@ -609,6 +621,15 @@
 			"parents":
 			[
 				{ "class": "tree_row", "attributes": ["hover"] }
+			],
+			"layer1.texture": "Material Theme/assets/commons/folder--hover.png",
+		},
+
+		{
+			"class": "icon_folder",
+			"parents":
+			[
+				{ "class": "tree_row", "attributes": ["selected"] }
 			],
 			"layer1.texture": "Material Theme/assets/commons/folder--hover.png",
 		},


### PR DESCRIPTION
Hi,

I'm using Vintage mode, and I navigate sidebar with keyboard (Focus with Ctrl + 0 and navigate).
Files are highlighted when selected with white font color, but folders are not highlighted at all, so you cannot know on which folder focus is at the moment when you are navigating. This PR adds highlight with white font color and folder hover image. Here's the screenshot:
![screenshot_2015-06-18_14-23-47](https://cloud.githubusercontent.com/assets/1782860/8231008/ad0ca778-15c5-11e5-8891-c0d31fa16a2a.png)
