### PR TITLE
Adjusting install.txt to actually fit into the 80 columns

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -1,47 +1,50 @@
-___  ___      _            _       _ 	   _____ _
-|  \/  |     | |          (_)     | |	  |_   _| |
-| .  . | __ _| |_ ___ _ __ _  __ _| |	    | | | |__   ___ _ __ ___   ___
-| |\/| |/ _` | __/ _ \ '__| |/ _` | |	    | | | '_ \ / _ \ '_ ` _ \ / _ \
-| |  | | (_| | ||  __/ |  | | (_| | |	    | | | | | |  __/ | | | | |  __/
-\_|  |_/\__,_|\__\___|_|  |_|\__,_|_|	    \_/ |_| |_|\___|_| |_| |_|\___|
+___  ___      _            _       _       _____ _
+|  \/  |     | |          (_)     | |     |_   _| |
+| .  . | __ _| |_ ___ _ __ _  __ _| |       | | | |__   ___ _ __ ___   ___
+| |\/| |/ _` | __/ _ \ '__| |/ _` | |       | | | '_ \ / _ \ '_ ` _ \ / _ \
+| |  | | (_| | ||  __/ |  | | (_| | |       | | | | | |  __/ | | | | |  __/
+\_|  |_/\__,_|\__\___|_|  |_|\__,_|_|       \_/ |_| |_|\___|_| |_| |_|\___|
 
 Material Theme for Sublime Text 3
 https://github.com/equinusocio/material-theme
 
-********************************************************************************
+******************************************************************************
 
 
 To activate this awesome theme, add in your current settings this code:
 
 {
-	"theme": "Material-Theme.sublime-theme",
-	"color_scheme": "Packages/Material Theme/schemes/Material-Theme.tmTheme",
+    "theme": "Material-Theme.sublime-theme",
+    "color_scheme": "Packages/Material Theme/schemes/Material-Theme.tmTheme",
 }
 
 
 MAKE SURE TO RESTART SUBLIME AFTER ACTIVATING THE THEME
-********************************************************************************
+******************************************************************************
 
 
 You can set the alternative darker (panels) version with this:
 
 {
-	"theme": "Material-Theme-Darker.sublime-theme",
+    "theme": "Material-Theme-Darker.sublime-theme",
 }
 
-********************************************************************************
+******************************************************************************
 
 
 Recommended UI and font settings:
 I suggest you to use this custom settings for a better experience with the theme:
+
 {
-  "overlay_scroll_bars": "enabled",
-  "line_padding_top": 3,
-  "line_padding_bottom": 3,
-  "font_options": [ "gray_antialias" ], // On retina Mac
-  "always_show_minimap_viewport": true,
-  "bold_folder_labels": true
-  "indent_guide_options": [ "draw_normal", "draw_active" ], //Highlight active indent
+    "overlay_scroll_bars": "enabled",
+    "line_padding_top": 3,
+    "line_padding_bottom": 3,
+    // On retina Mac
+    "font_options": [ "gray_antialias" ],
+    "always_show_minimap_viewport": true,
+    "bold_folder_labels": true,
+    // Highlight active indent
+    "indent_guide_options": [ "draw_normal", "draw_active" ]
 }
 
-********************************************************************************
+******************************************************************************


### PR DESCRIPTION
This basically removes `**` from each of the separating lines. That's helpful because Package Control prepends every line in the messages window with two spaces.

This also fixes the commas in the recommended settings section.