### PR TITLE
Increase selected text contrast on darker theme

### DIFF
--- a/schemes/Material-Theme-Darker.tmTheme
+++ b/schemes/Material-Theme-Darker.tmTheme
@@ -27,7 +27,7 @@
 				<key>lineHighlight</key>
 				<string>#00000030</string>
 				<key>selection</key>
-				<string>#61616120</string>
+				<string>#61616180</string>
 				<key>guide</key>
 				<string>#42424260</string>
 				<key>activeGuide</key>


### PR DESCRIPTION
I find the selected text contrast on the darker theme is much too subtle. Here's a comparison between the current color vs. the modified one in this PR.

![comparison](https://cloud.githubusercontent.com/assets/315202/8690162/d9601bfc-2a7e-11e5-8964-4677d6bc0185.png)

![comparison-2](https://cloud.githubusercontent.com/assets/315202/8690194/50bd8a2c-2a7f-11e5-816b-964a16e7579d.png)