### PR TITLE
Resolve a "white background" bug on autocomplete popup (Darker version)

### DIFF
--- a/Material-Theme-Darker.sublime-theme
+++ b/Material-Theme-Darker.sublime-theme
@@ -83,7 +83,7 @@
 
 		{
 			"class": "popup_control",
-			"layer0.texture": [255, 255, 255, 255],
+			"layer0.tint": [33, 33, 33],
 			"layer0.opacity": 1.0,
 			"content_margin": [0, 0]
 		},


### PR DESCRIPTION
Hello and thank you for the awesome job on this theme :)

I think I've found a little bug in the "darker" version of the theme where the auto_complete popup seems to have a white background. This background is visible a very short instant when you trying to close the auto_complete popup with "esc" for example.

Thank you and keep the good work :+1: 