### PR TITLE
Improve readability for sidebar files and statusbar

### DIFF
--- a/Material-Theme-Lighter.sublime-theme
+++ b/Material-Theme-Lighter.sublime-theme
@@ -546,7 +546,6 @@
 		{
 			"class": "sidebar_label",
 			"color": [110, 119, 123],
-			// "color": [160, 173, 179],
 			"font.bold": false,
 			"font.italic": false,
 			"shadow_color": [255, 255, 255, 0],

--- a/Material-Theme-Lighter.sublime-theme
+++ b/Material-Theme-Lighter.sublime-theme
@@ -545,7 +545,8 @@
 
 		{
 			"class": "sidebar_label",
-			"color": [176, 190, 197],
+			"color": [110, 119, 123],
+			// "color": [160, 173, 179],
 			"font.bold": false,
 			"font.italic": false,
 			"shadow_color": [255, 255, 255, 0],
@@ -555,7 +556,7 @@
 		{
 			"class": "sidebar_label",
 			"parents": [{"class": "tree_row", "attributes": ["hover"]}],
-			"color": [144, 164, 174],
+			"color": [69, 90, 100],
 			"shadow_color": [255, 255, 255, 0],
 			"shadow_offset": [0, 0]
 		},
@@ -563,7 +564,7 @@
 		{
 			"class": "sidebar_label",
 			"parents": [{"class": "tree_row", "attributes": ["selected"]}],
-			"font.bold": false,
+			"font.bold": true,
 			"color": [69, 90, 100]
 		},
 
@@ -2845,7 +2846,7 @@
 			"class": "tabset_control",
 			"settings": ["material_theme_tabs_autowidth"],
 			"tab_width": 0
-		},   
+		},
 
 		{
 			"class": "tab_control",
@@ -2860,7 +2861,7 @@
 			"layer3.texture": "Material Theme/assets/commons/tab_separator.png",
 			"layer3.inner_margin": [1, 1],
 			"layer3.opacity": 1.0,
-		},       
+		},
 
 			// Tab Labels
 
@@ -3024,6 +3025,6 @@
 			"layer1.texture": "Material Theme/assets/commons/panel_separator.png",
 			"layer1.opacity": 0.1,
 			"layer1.inner_margin": [2, 2, 2, 2],
-		},    
+		},
 
 ]

--- a/Material-Theme-Lighter.sublime-theme
+++ b/Material-Theme-Lighter.sublime-theme
@@ -1042,7 +1042,7 @@
 		 {
 			  "class": "label_control",
 			  "parents": [{"class": "status_bar"}],
-			  "color": [144, 164, 174],
+			  "color": [110, 119, 123],
 			  "font.bold": false
 		},
 


### PR DESCRIPTION
Hello, I loved Material Light theme and I have been using it during day light (for nights I prefer dark themes).

However I found that files at sidebar and statusbar was too hard to read and I darkened it a bit. Here is a how it is now (with Solarized Light theme):

![image](https://cloud.githubusercontent.com/assets/208856/10123177/e98bd51a-6508-11e5-8a31-8b3fb6661538.png)
