### PR TITLE
Unify escaped charactors color in REGEX

### DIFF
--- a/schemes/Material-Theme-Darker.tmTheme
+++ b/schemes/Material-Theme-Darker.tmTheme
@@ -76,7 +76,7 @@
 				<key>foreground</key>
 				<string>#CDD3DE</string> <!-- text colour -->
 			</dict>
-		</dict>        
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Punctuation</string>
@@ -242,7 +242,7 @@ keyword.operator, constant.other.color, meta.tag, punctuation.definition.tag, pu
 				<key>foreground</key>
 				<string>#C3E88D</string>
 			</dict>
-		</dict>		
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Boolean</string>
@@ -502,7 +502,7 @@ meta.property-value support.constant.named-color.css</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#80CBC4</string>
+				<string>#F77669</string>
 			</dict>
 		</dict>
 		<dict>
@@ -751,7 +751,7 @@ meta.property-value support.constant.named-color.css</string>
 				<key>foreground</key>
 				<string>#FFEB95</string>
 			</dict>
-		</dict>     
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>CSS: Property-name</string>
@@ -817,7 +817,7 @@ meta.property-value support.constant.named-color.css</string>
 				<key>foreground</key>
 				<string>#C3E88D</string>
 			</dict>
-		</dict>      
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>CSS: #</string>

--- a/schemes/Material-Theme-Lighter.tmTheme
+++ b/schemes/Material-Theme-Lighter.tmTheme
@@ -41,7 +41,7 @@
 				<key>findHighlight</key>
 				<string>#F8E71C</string>
 				<key>tagsOptions</key>
-				<string>underline</string>            
+				<string>underline</string>
 				<key>shadow</key>
 				<string>#90A4AE50</string>
 			</dict>
@@ -244,7 +244,7 @@ keyword.operator, constant.other.color, meta.tag, punctuation.definition.tag, pu
 				<key>foreground</key>
 				<string>#C3E88D</string>
 			</dict>
-		</dict>		
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Boolean</string>
@@ -504,7 +504,7 @@ meta.property-value support.constant.named-color.css</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#3fb3a8ff</string>
+				<string>#E53935</string>
 			</dict>
 		</dict>
 		<dict>
@@ -823,7 +823,7 @@ meta.property-value support.constant.named-color.css</string>
 				<key>foreground</key>
 				<string>#C3E88D</string>
 			</dict>
-		</dict>      
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>CSS: #</string>
@@ -889,7 +889,7 @@ meta.property-value support.constant.named-color.css</string>
 				<key>foreground</key>
 				<string>#7986CB</string>
 			</dict>
-		</dict>		
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>133d1250-19c6-4565-bc93-b37fd36f7fc9</string>

--- a/schemes/Material-Theme.tmTheme
+++ b/schemes/Material-Theme.tmTheme
@@ -76,7 +76,7 @@
 				<key>foreground</key>
 				<string>#CDD3DE</string> <!-- text colour -->
 			</dict>
-		</dict>     
+		</dict>
 		<dict>
 			<key>name</key>
 			<string>Punctuation</string>
@@ -502,7 +502,7 @@ meta.property-value support.constant.named-color.css</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#80CBC4</string>
+				<string>#F77669</string>
 			</dict>
 		</dict>
 		<dict>
@@ -883,7 +883,7 @@ meta.property-value support.constant.named-color.css</string>
 				<key>foreground</key>
 				<string>#7986CB</string>
 			</dict>
-		</dict>		
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>133d1250-19c6-4565-bc93-b37fd36f7fc9</string>


### PR DESCRIPTION
JS file and Ruby files' REGEX display in different kind of format.

<img width="842" alt="2015-10-15 15 46 11" src="https://cloud.githubusercontent.com/assets/2749593/10507944/adee22fe-7356-11e5-8cb3-590a299076cd.png">
<img width="532" alt="2015-10-15 15 49 10" src="https://cloud.githubusercontent.com/assets/2749593/10507946/afef7396-7356-11e5-89ff-0c3e151607a6.png">

I prefer the first example of JS files for the escaped characters to stand out, so I modified the color to match it. Thanks for you time.