### PR TITLE
Missing comma in recommended settings JSON

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -41,7 +41,7 @@ Recommended UI and font settings for a better experience:
 	"line_padding_bottom": 3,
 	"always_show_minimap_viewport": true,
 	"bold_folder_labels": true,
-	"indent_guide_options": [ "draw_normal", "draw_active" ]    // Highlight active indent
+	"indent_guide_options": [ "draw_normal", "draw_active" ],   // Highlight active indent
 	"font_options": [ "gray_antialias" ],                       // For retina Mac
 }
 


### PR DESCRIPTION
Simple syntax error that doesn't allow straight copying and pasting of recommended settings.