### PR TITLE
Add Markdown strikethrough support

### DIFF
--- a/schemes/Material-Theme-Darker-OceanicNext.tmTheme
+++ b/schemes/Material-Theme-Darker-OceanicNext.tmTheme
@@ -60,7 +60,7 @@
       <key>name</key>
       <string>Comments</string>
       <key>scope</key>
-      <string>comment, punctuation.definition.comment</string>
+      <string>comment, punctuation.definition.comment, markup.strikethrough</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>

--- a/schemes/Material-Theme-Darker.tmTheme
+++ b/schemes/Material-Theme-Darker.tmTheme
@@ -72,7 +72,7 @@
       <key>name</key>
       <string>Comments</string>
       <key>scope</key>
-      <string>comment, punctuation.definition.comment</string>
+      <string>comment, punctuation.definition.comment, markup.strikethrough</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>

--- a/schemes/Material-Theme-Lighter.tmTheme
+++ b/schemes/Material-Theme-Lighter.tmTheme
@@ -61,7 +61,7 @@
 			<key>name</key>
 			<string>Comments</string>
 			<key>scope</key>
-			<string>comment, punctuation.definition.comment</string>
+			<string>comment, punctuation.definition.comment, markup.strikethrough</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/schemes/Material-Theme-OceanicNext.tmTheme
+++ b/schemes/Material-Theme-OceanicNext.tmTheme
@@ -60,7 +60,7 @@
       <key>name</key>
       <string>Comments</string>
       <key>scope</key>
-      <string>comment, punctuation.definition.comment</string>
+      <string>comment, punctuation.definition.comment, markup.strikethrough</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>

--- a/schemes/Material-Theme.tmTheme
+++ b/schemes/Material-Theme.tmTheme
@@ -59,7 +59,7 @@
 			<key>name</key>
 			<string>Comments</string>
 			<key>scope</key>
-			<string>comment, punctuation.definition.comment</string>
+			<string>comment, punctuation.definition.comment, markup.strikethrough</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>


### PR DESCRIPTION
Add support of Strikethrough words in Markdown (used with ~~ before and
after the words).