### PR TITLE
Add more contrast to selection

### DIFF
--- a/schemes/Material-Theme-Darker-OceanicNext.tmTheme
+++ b/schemes/Material-Theme-Darker-OceanicNext.tmTheme
@@ -33,7 +33,7 @@
         <key>caret</key>
         <string>#FFCC00</string>
         <key>foreground</key>
-        <string>#c0c5ce70</string>
+        <string>#D4DADEFF</string>
         <key>invisibles</key>
         <string>#65737e</string>
         <key>lineHighlight</key>

--- a/schemes/Material-Theme-Darker.tmTheme
+++ b/schemes/Material-Theme-Darker.tmTheme
@@ -34,7 +34,7 @@
         <key>caret</key>
         <string>#FFCC00</string>
         <key>foreground</key>
-        <string>#c0c5ce70</string>
+        <string>#D4DADEFF</string>
         <key>invisibles</key>
         <string>#65737e</string>
         <key>lineHighlight</key>

--- a/schemes/Material-Theme-OceanicNext.tmTheme
+++ b/schemes/Material-Theme-OceanicNext.tmTheme
@@ -33,7 +33,7 @@
         <key>caret</key>
         <string>#FFCC00</string>
         <key>foreground</key>
-        <string>#80CBC470</string>
+        <string>#D4DADEFF</string>
         <key>invisibles</key>
         <string>#65737e</string>
         <key>lineHighlight</key>

--- a/schemes/Material-Theme.tmTheme
+++ b/schemes/Material-Theme.tmTheme
@@ -21,7 +21,7 @@
 				<key>caret</key>
 				<string>#FFCC00</string>
 				<key>foreground</key>
-				<string>#80CBC470</string>
+				<string>#D4DADEFF</string>
 				<key>invisibles</key>
 				<string>#65737e</string>
 				<key>lineHighlight</key>


### PR DESCRIPTION
By changing the foreground value to a lighter one, contrast with words
while selected is higher, so text is more readable.
If foreground value is used for other things, there appearance will
also change