### PR TITLE
Add Border to current selection so selection is more visible

### DIFF
--- a/schemes/Material-Theme-Darker-OceanicNext.tmTheme
+++ b/schemes/Material-Theme-Darker-OceanicNext.tmTheme
@@ -54,6 +54,8 @@
         <string>underline</string>
         <key>shadow</key>
         <string>#00000010</string>
+        <key>selectionBorder</key>
+        <string>#5A647E</string>
       </dict>
     </dict>
     <dict>

--- a/schemes/Material-Theme-Darker.tmTheme
+++ b/schemes/Material-Theme-Darker.tmTheme
@@ -55,6 +55,8 @@
         <string>underline</string>
         <key>shadow</key>
         <string>#00000010</string>
+        <key>selectionBorder</key>
+        <string>#5A647E</string>
       </dict>
     </dict>
     <dict>

--- a/schemes/Material-Theme-OceanicNext.tmTheme
+++ b/schemes/Material-Theme-OceanicNext.tmTheme
@@ -54,6 +54,8 @@
         <string>underline</string>
         <key>shadow</key>
         <string>#00000010</string>
+        <key>selectionBorder</key>
+        <string>#5A647E</string>
       </dict>
     </dict>
     <dict>

--- a/schemes/Material-Theme.tmTheme
+++ b/schemes/Material-Theme.tmTheme
@@ -42,6 +42,8 @@
 				<string>underline</string>
 				<key>shadow</key>
 				<string>#00000010</string>
+		        <key>selectionBorder</key>
+		        <string>#5A647E</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Add a border to selection to Dark and Normal themes, so the selection
is more visible when present in large text.