### PR TITLE
Made comments slightly more readable

### DIFF
--- a/schemes/Material-Theme-Darker-OceanicNext.tmTheme
+++ b/schemes/Material-Theme-Darker-OceanicNext.tmTheme
@@ -66,7 +66,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#444444</string>
+        <string>#656565</string>
       </dict>
     </dict>
     <dict>


### PR DESCRIPTION
Hi there, everyone I know who loves this scheme ends up making the comments slightly lighter and more readable (especially for longer comments).

**Before:**
![comments-before](https://cloud.githubusercontent.com/assets/875921/12663324/16f18ff6-c68c-11e5-8f3f-554b89ad013f.png)


**After:**
![comments-after](https://cloud.githubusercontent.com/assets/875921/12663325/1bc591d0-c68c-11e5-9628-d416c2dc14f4.png)

