### PR TITLE
fix html tag colorus in php files | lighten comment strings slightly

### DIFF
--- a/schemes/Material-Theme-Darker-OceanicNext.tmTheme
+++ b/schemes/Material-Theme-Darker-OceanicNext.tmTheme
@@ -66,7 +66,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#444444</string>
+        <string>#656565</string>
       </dict>
     </dict>
     <dict>

--- a/schemes/Material-Theme-Darker.tmTheme
+++ b/schemes/Material-Theme-Darker.tmTheme
@@ -78,7 +78,7 @@
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#444444</string>
+        <string>#656565</string>
       </dict>
     </dict>
     <dict>
@@ -918,7 +918,7 @@ meta.property-value support.constant.named-color.css</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
-        <string>#DDDDDD</string>
+        <string>#ff5370</string>
       </dict>
     </dict>
     <dict>


### PR DESCRIPTION
@equinusocio Pull Request to correct the HTML tag colour in PHP documents. Also lightened comments slightly for readability.

Let me know any thoughts you have here and if you need assistance elsewhere.