### PR TITLE
Support for ESLint and Babel config file types

### DIFF
--- a/langs/Babel JSON.xml
+++ b/langs/Babel JSON.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>name</key>
+    <string>Babel JSON</string>
+    <key>fileTypes</key>
+    <array>
+      <string>.babelrc</string>
+    </array>
+    <key>patterns</key>
+    <array>
+      <dict>
+        <key>include</key>
+        <string>source.json</string>
+      </dict>
+    </array>
+    <key>scopeName</key>
+    <string>source.json, source.json.babelrc</string>
+  </dict>
+</plist>

--- a/langs/ESLint JSON.tmLanguage
+++ b/langs/ESLint JSON.tmLanguage
@@ -16,6 +16,6 @@
       </dict>
     </array>
     <key>scopeName</key>
-    <string>source.json, source.eslintrc</string>
+    <string>source.json, source.json.eslintrc</string>
   </dict>
 </plist>

--- a/langs/ESLint JSON.tmLanguage
+++ b/langs/ESLint JSON.tmLanguage
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>name</key>
+    <string>ESLint JSON</string>
+    <key>fileTypes</key>
+    <array>
+      <string>.eslintrc</string>
+    </array>
+    <key>patterns</key>
+    <array>
+      <dict>
+        <key>include</key>
+        <string>source.json</string>
+      </dict>
+    </array>
+    <key>scopeName</key>
+    <string>source.json, source.eslintrc</string>
+  </dict>
+</plist>


### PR DESCRIPTION
Support for ESLint and Babel config file types (`.eslintrc` and `.babelrc`) for JSON syntax highlighting:

![image](https://cloud.githubusercontent.com/assets/359871/13120270/ae8e02fa-d572-11e5-9a87-7d74a6ff92ea.png)
