### PR TITLE
Gruntfile keyboard shortcut commenting support

### DIFF
--- a/langs/Babel JSON.xml
+++ b/langs/Babel JSON.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>name</key>
+    <string>Babel JSON</string>
+    <key>fileTypes</key>
+    <array>
+      <string>.babelrc</string>
+    </array>
+    <key>patterns</key>
+    <array>
+      <dict>
+        <key>include</key>
+        <string>source.json</string>
+      </dict>
+    </array>
+    <key>scopeName</key>
+    <string>source.json, source.json.babelrc</string>
+  </dict>
+</plist>

--- a/langs/ESLint JSON.tmLanguage
+++ b/langs/ESLint JSON.tmLanguage
@@ -16,6 +16,6 @@
       </dict>
     </array>
     <key>scopeName</key>
-    <string>source.json, source.eslintrc</string>
+    <string>source.json, source.json.eslintrc</string>
   </dict>
 </plist>

--- a/langs/ESLint JSON.tmLanguage
+++ b/langs/ESLint JSON.tmLanguage
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>name</key>
+    <string>ESLint JSON</string>
+    <key>fileTypes</key>
+    <array>
+      <string>.eslintrc</string>
+    </array>
+    <key>patterns</key>
+    <array>
+      <dict>
+        <key>include</key>
+        <string>source.json</string>
+      </dict>
+    </array>
+    <key>scopeName</key>
+    <string>source.json, source.eslintrc</string>
+  </dict>
+</plist>

--- a/prefs/icon_gruntfile.tmPreferences
+++ b/prefs/icon_gruntfile.tmPreferences
@@ -8,6 +8,27 @@
         <dict>
             <key>icon</key>
             <string>file_type_gruntfile</string>
+            <key>shellVariables</key>
+            <array>
+               <dict>
+                  <key>name</key>
+                  <string>TM_COMMENT_START</string>
+                  <key>value</key>
+                  <string>// </string>
+               </dict>
+               <dict>
+                  <key>name</key>
+                  <string>TM_COMMENT_START_2</string>
+                  <key>value</key>
+                  <string>/*</string>
+               </dict>
+               <dict>
+                  <key>name</key>
+                  <string>TM_COMMENT_END_2</string>
+                  <key>value</key>
+                  <string>*/</string>
+               </dict>
+            </array>
         </dict>
     </dict>
 </plist>


### PR DESCRIPTION
Support so you’re able to comment/uncomment `Gruntfile.js` via the CMD+/ (Mac) or CTRL+/ (Windows) keyboard shortcut