### PR TITLE
Modify minimap viewport color for darker theme

### DIFF
--- a/Material-Theme-Darker.sublime-theme
+++ b/Material-Theme-Darker.sublime-theme
@@ -1015,8 +1015,8 @@
   {
     "class": "minimap_control",
     "settings": ["always_show_minimap_viewport"],
-    "viewport_color": [255, 255, 255, 50],
-    "viewport_opacity": 0.4,
+    "viewport_color": [0, 255, 0, 50],
+    "viewport_opacity": 0.9,
   },
 
   {


### PR DESCRIPTION
Original minimap viewport color doesn't work well with light color schemes (e.g. github color scheme), so I decided to make it look green since it's a rarely used for most color schemes.