### PR TITLE
Make lighter's activeGuide easier to see

### DIFF
--- a/schemes/Material-Theme-Lighter.tmTheme
+++ b/schemes/Material-Theme-Lighter.tmTheme
@@ -33,7 +33,7 @@
         <key>guide</key>
         <string>#B0BEC570</string>
         <key>activeGuide</key>
-        <string>#0000070</string>
+        <string>#00000070</string>
         <key>stackGuide</key>
         <string>#B0BEC580</string>
         <key>gutterForeground</key>


### PR DESCRIPTION
I thought I should try fixing #749 myself, since it's just an xml file!

Before:
![before](https://cloud.githubusercontent.com/assets/9897819/14446501/9f1237ec-000b-11e6-807e-0611ae19407a.png)

After:
![after](https://cloud.githubusercontent.com/assets/9897819/14446495/883e5cf8-000b-11e6-916a-24fd3a55757c.png)

**Edit** I probably should've given my commit a more useful comment like saying that it fixes my issue. Sorry.
