### PR TITLE
fix php html tag color

### DIFF
--- a/schemes/OLD/Material-Theme-Darker.tmTheme
+++ b/schemes/OLD/Material-Theme-Darker.tmTheme
@@ -892,7 +892,7 @@ meta.property-value support.constant.named-color.css</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#DDDDDD</string>
+				<string>#ff5370</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Change tag color from white back to pink like it should be. It's been like this for months and I've been having to update the sublime-package manually each update. Hopefully I won't have to do that anymore. 