### PR TITLE
Removed comments from dependencies.json

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,21 +1,4 @@
 {
-  // BE SURE TO REMOVE THESE COMMENTS BEFORE USING THIS TEMPLATE SINCE
-  // COMMENTS ARE NOT ALLOWED IN JSON
-
-  // This file is a filesystem-level solution for specifying dependencies
-  // for packages. This is most useful for package developers since they are
-  // not installing their own packages from a repository or channel, and
-  // need to make sure Package Control installs the dependencies they need.
-
-  // The file contains two levels of selectors, platform and Sublime Text
-  // version, to pick what set of dependencies should be installed.
-  // The most-specific selectors will be used, and all other ignored. This
-  // means that some dependencies will be duplicated under a specific
-  // platform and under *.
-
-
-  // Matching of platform and version selectors is exclusive. Thus, these
-  // dependencies will only be installed if no other keys matched first.
   "*": {
     ">=3118": [
       "mdpopups",


### PR DESCRIPTION
#### Description
The JSON specification doesn't support comments in `.json` files, so this removes them from `dependencies.json`.

#### Motivation and Context
Package control cannot parse the `dependencies.json` file because comments are invalid JSON.
https://github.com/equinusocio/material-theme/issues/925

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

