### PR TITLE
Fix disabled folder animations for all themes

### DIFF
--- a/.src/themes/darker/options.json
+++ b/.src/themes/darker/options.json
@@ -50,6 +50,183 @@
     "content_margin": [0, 0]
   },
 
+    // Folder animation
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/commons/folder--hover.png",
+  },
+
+    // Folder animation Lime
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_lime"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-lime/folder--hover.png",
+  },
+
+    // Folder animation Purple
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_purple"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-purple/folder--hover.png",
+  },
+
+    // Folder animation Red
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_red"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-red/folder--hover.png",
+  },
+
+    // Folder animation Orange
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_orange"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-orange/folder--hover.png",
+  },
+
+    // Folder animation Yellow
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_yellow"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
+  },
+
+
+    // Folder animation Indigo
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_indigo"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
+  },
+
+    // Folder animation Pink
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_pink"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-pink/folder--hover.png",
+  },
+
+    // Folder animation Blue
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_blue"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-blue/folder--hover.png",
+  },
+
+    // Folder animation Cyan
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_cyan"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
+  },
+
+    // Folder animation Bright teal
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_bright-teal"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
+  },
+
+    // Folder animation Acid lime
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_acid-lime"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
+  },
+
+    // Folder animation Graphite
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_graphite"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
+  },
+
+    // Folder animation Breaking bad
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_brba"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-brba/folder--hover.png",
+  },
+
+    // Folder animation Sky
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_sky"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-sky/folder--hover.png",
+  },
+
+    // Folder animation Tomato
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_tomato"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
+  },
+
     // Small status bar
 
   {

--- a/.src/themes/default/options.json
+++ b/.src/themes/default/options.json
@@ -62,6 +62,172 @@
     "layer3.texture": "Material Theme/assets/commons/folder--hover.png",
   },
 
+    // Folder animation Lime
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_lime"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-lime/folder--hover.png",
+  },
+
+    // Folder animation Purple
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_purple"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-purple/folder--hover.png",
+  },
+
+    // Folder animation Red
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_red"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-red/folder--hover.png",
+  },
+
+    // Folder animation Orange
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_orange"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-orange/folder--hover.png",
+  },
+
+    // Folder animation Yellow
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_yellow"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
+  },
+
+
+    // Folder animation Indigo
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_indigo"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
+  },
+
+    // Folder animation Pink
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_pink"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-pink/folder--hover.png",
+  },
+
+    // Folder animation Blue
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_blue"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-blue/folder--hover.png",
+  },
+
+    // Folder animation Cyan
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_cyan"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
+  },
+
+    // Folder animation Bright teal
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_bright-teal"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
+  },
+
+    // Folder animation Acid lime
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_acid-lime"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
+  },
+
+    // Folder animation Graphite
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_graphite"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
+  },
+
+    // Folder animation Breaking bad
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_brba"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-brba/folder--hover.png",
+  },
+
+    // Folder animation Sky
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_sky"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-sky/folder--hover.png",
+  },
+
+    // Folder animation Tomato
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_tomato"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
+  },
+
     // Small status bar
 
   {

--- a/.src/themes/lighter/options.json
+++ b/.src/themes/lighter/options.json
@@ -50,6 +50,183 @@
     "content_margin": [0, 0]
   },
 
+    // Folder animation
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/commons/folder--hover.png",
+  },
+
+    // Folder animation Lime
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_lime"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-lime/folder--hover.png",
+  },
+
+    // Folder animation Purple
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_purple"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-purple/folder--hover.png",
+  },
+
+    // Folder animation Red
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_red"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-red/folder--hover.png",
+  },
+
+    // Folder animation Orange
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_orange"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-orange/folder--hover.png",
+  },
+
+    // Folder animation Yellow
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_yellow"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
+  },
+
+
+    // Folder animation Indigo
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_indigo"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
+  },
+
+    // Folder animation Pink
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_pink"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-pink/folder--hover.png",
+  },
+
+    // Folder animation Blue
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_blue"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-blue/folder--hover.png",
+  },
+
+    // Folder animation Cyan
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_cyan"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
+  },
+
+    // Folder animation Bright teal
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_bright-teal"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
+  },
+
+    // Folder animation Acid lime
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_acid-lime"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
+  },
+
+    // Folder animation Graphite
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_graphite"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
+  },
+
+    // Folder animation Breaking bad
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_brba"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-brba/folder--hover.png",
+  },
+
+    // Folder animation Sky
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_sky"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-sky/folder--hover.png",
+  },
+
+    // Folder animation Tomato
+
+  {
+    "class": "icon_folder",
+    "settings": ["material_theme_disable_folder_animation", "material_theme_accent_tomato"],
+    "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+    "layer1.opacity": 0.0,
+    "layer2.opacity": 0.0,
+    "layer3.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
+  },
+
     // Small status bar
 
   {

--- a/Material-Theme-Darker.sublime-theme
+++ b/Material-Theme-Darker.sublime-theme
@@ -6113,6 +6113,183 @@
       "content_margin": [0, 0]
     },
   
+      // Folder animation
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/commons/folder--hover.png",
+    },
+  
+      // Folder animation Lime
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_lime"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-lime/folder--hover.png",
+    },
+  
+      // Folder animation Purple
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_purple"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-purple/folder--hover.png",
+    },
+  
+      // Folder animation Red
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_red"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-red/folder--hover.png",
+    },
+  
+      // Folder animation Orange
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_orange"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-orange/folder--hover.png",
+    },
+  
+      // Folder animation Yellow
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_yellow"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
+    },
+  
+  
+      // Folder animation Indigo
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_indigo"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
+    },
+  
+      // Folder animation Pink
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_pink"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-pink/folder--hover.png",
+    },
+  
+      // Folder animation Blue
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_blue"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-blue/folder--hover.png",
+    },
+  
+      // Folder animation Cyan
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_cyan"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
+    },
+  
+      // Folder animation Bright teal
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_bright-teal"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
+    },
+  
+      // Folder animation Acid lime
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_acid-lime"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
+    },
+  
+      // Folder animation Graphite
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_graphite"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
+    },
+  
+      // Folder animation Breaking bad
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_brba"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-brba/folder--hover.png",
+    },
+  
+      // Folder animation Sky
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_sky"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-sky/folder--hover.png",
+    },
+  
+      // Folder animation Tomato
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_tomato"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
+    },
+  
       // Small status bar
   
     {

--- a/Material-Theme-Lighter.sublime-theme
+++ b/Material-Theme-Lighter.sublime-theme
@@ -6120,6 +6120,183 @@
       "content_margin": [0, 0]
     },
   
+      // Folder animation
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/commons/folder--hover.png",
+    },
+  
+      // Folder animation Lime
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_lime"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-lime/folder--hover.png",
+    },
+  
+      // Folder animation Purple
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_purple"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-purple/folder--hover.png",
+    },
+  
+      // Folder animation Red
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_red"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-red/folder--hover.png",
+    },
+  
+      // Folder animation Orange
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_orange"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-orange/folder--hover.png",
+    },
+  
+      // Folder animation Yellow
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_yellow"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
+    },
+  
+  
+      // Folder animation Indigo
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_indigo"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
+    },
+  
+      // Folder animation Pink
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_pink"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-pink/folder--hover.png",
+    },
+  
+      // Folder animation Blue
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_blue"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-blue/folder--hover.png",
+    },
+  
+      // Folder animation Cyan
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_cyan"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
+    },
+  
+      // Folder animation Bright teal
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_bright-teal"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
+    },
+  
+      // Folder animation Acid lime
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_acid-lime"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
+    },
+  
+      // Folder animation Graphite
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_graphite"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
+    },
+  
+      // Folder animation Breaking bad
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_brba"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-brba/folder--hover.png",
+    },
+  
+      // Folder animation Sky
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_sky"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-sky/folder--hover.png",
+    },
+  
+      // Folder animation Tomato
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_tomato"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
+    },
+  
       // Small status bar
   
     {

--- a/Material-Theme.sublime-theme
+++ b/Material-Theme.sublime-theme
@@ -6145,6 +6145,172 @@
       "layer3.texture": "Material Theme/assets/commons/folder--hover.png",
     },
   
+      // Folder animation Lime
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_lime"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-lime/folder--hover.png",
+    },
+  
+      // Folder animation Purple
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_purple"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-purple/folder--hover.png",
+    },
+  
+      // Folder animation Red
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_red"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-red/folder--hover.png",
+    },
+  
+      // Folder animation Orange
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_orange"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-orange/folder--hover.png",
+    },
+  
+      // Folder animation Yellow
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_yellow"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-yellow/folder--hover.png",
+    },
+  
+  
+      // Folder animation Indigo
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_indigo"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-indigo/folder--hover.png",
+    },
+  
+      // Folder animation Pink
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_pink"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-pink/folder--hover.png",
+    },
+  
+      // Folder animation Blue
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_blue"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-blue/folder--hover.png",
+    },
+  
+      // Folder animation Cyan
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_cyan"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-cyan/folder--hover.png",
+    },
+  
+      // Folder animation Bright teal
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_bright-teal"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-bright-teal/folder--hover.png",
+    },
+  
+      // Folder animation Acid lime
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_acid-lime"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-acid-lime/folder--hover.png",
+    },
+  
+      // Folder animation Graphite
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_graphite"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-graphite/folder--hover.png",
+    },
+  
+      // Folder animation Breaking bad
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_brba"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-brba/folder--hover.png",
+    },
+  
+      // Folder animation Sky
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_sky"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-sky/folder--hover.png",
+    },
+  
+      // Folder animation Tomato
+  
+    {
+      "class": "icon_folder",
+      "settings": ["material_theme_disable_folder_animation", "material_theme_accent_tomato"],
+      "parents": [{ "class": "tree_row", "attributes": ["expanded", "hover"] }],
+      "layer1.opacity": 0.0,
+      "layer2.opacity": 0.0,
+      "layer3.texture": "Material Theme/assets/accent-tomato/folder--hover.png",
+    },
+  
       // Small status bar
   
     {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can also manually activate this theme by adding these lines to your user set
 This theme provide a visual configuration tool that allow you to configure the theme by activating the available options from an inline popup. Just right click in your editor and choose `Material Theme > Material Theme Config`. You can also open the configurator from the command palette by searching `Material Theme > Configuration`
 
 #### Advanced configuration
-If you like the adnvaced text text-configuration you can use it by the `Material Theme > Advanced condiguration` command both form context menu and command palette.
+If you like the advanced text text-configuration you can use it by the `Material Theme > Advanced configuration` command both from context menu and command palette.
 
 #### Old Color Schemes
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Fixes disabled folder animations for all themes. Disabled folder animation code for all accent colours were added back that was deleted in b7446c299a4b0700d56be791eb3efabd9b8bd674. Also adds missing disabled folder animation code for the newer accent colours. Little bit of spelling also fixed in the README.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
b7446c299a4b0700d56be791eb3efabd9b8bd674 did not actually fix #943 properly. I noticed that even when I had folder animations disabled and using the dark or light theme, the animations were still there. Additionally, on the default theme, all accents would have the default teal coloured folder when hovering over with folder animations disabled (see screenshot).

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
I installed the changed theme over the old themes and then checked most of the accents on each of the themes to ensure that the folder animation worked.

#### Screenshots (if appropriate):
Using Default theme with red accent:

![diff](https://cloud.githubusercontent.com/assets/12944605/17638538/9e4cdbc4-60b8-11e6-868e-abab97a5fbf1.jpg)

I don't have a gif of the disabled folder animation issue on the Darker and Lighter themes.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
