### PR TITLE
Fixed typo in Preferences.sublime-settings

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -118,7 +118,7 @@
   // Disable the current file tree indicator
   "material_theme_disable_tree_indicator": false,
 
-  // Hide headin titles from the sidebar (only with Material Theme Appbar)
+  // Hide heading titles from the sidebar (only with Material Theme Appbar)
   "material_theme_tree_headings": false,
 
   //


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
#### Description

Changed `// Hide headin titles from the sidebar (only with Material Theme Appbar)` to `// Hide heading titles from the sidebar (only with Material Theme Appbar)` (line 121)
#### Motivation and Context

I was going through the code, saw a typo, fixed it. Nothing major.
