### PR TITLE
Add optional `A File Icon` installer

### DIFF
--- a/Icons.py
+++ b/Icons.py
@@ -1,0 +1,80 @@
+"""
+A File Icon Installer
+"""
+
+import os
+import sublime
+
+ICONS_PACKAGE = "A File Icon"
+PKGCTRL_SETTINGS = "Package Control.sublime-settings"
+
+THEME_NAME = os.path.splitext(
+    os.path.basename(os.path.dirname(__file__))
+)[0]
+
+MSG = """\
+<div id="afi-installer">
+  <style>
+    #afi-installer {{
+      padding: 1rem;
+      line-height: 1.5;
+    }}
+    #afi-installer code {{
+      background-color: color(var(--background) blend(var(--foreground) 80%));
+      line-height: 1;
+      padding: 0.25rem;
+    }}
+    #afi-installer a {{
+      padding: 0;
+      margin: 0;
+    }}
+  </style>
+
+  {} requires <code>A File Icon</code> package for enhanced<br>support of
+  the file-specific icons.
+  <br><br>Would you like to install it?<br>
+  <br><a href="install">Install</a> <a href="cancel">Cancel</a>
+</div>
+""".format(THEME_NAME)
+
+
+def is_installed():
+    pkgctrl_settings = sublime.load_settings(PKGCTRL_SETTINGS)
+
+    return ICONS_PACKAGE in set(pkgctrl_settings.get("installed_packages", []))
+
+
+def on_navigate(href):
+    if href.startswith("install"):
+        install()
+    else:
+        hide()
+
+
+def install():
+    print("Installing `{}` ...".format(ICONS_PACKAGE))
+    sublime.active_window().run_command(
+        "advanced_install_package", {"packages": ICONS_PACKAGE}
+    )
+    hide()
+
+
+def hide():
+    sublime.active_window().active_view().hide_popup()
+
+
+def plugin_loaded():
+    from package_control import events
+
+    if events.install(THEME_NAME) and not is_installed():
+        window = sublime.active_window()
+        view = window.active_view()
+        window.focus_view(view)
+        row = int(view.rowcol(view.visible_region().a)[0] + 1)
+        view.show_popup(
+            MSG,
+            location=view.text_point(row, 5),
+            max_width=800,
+            max_height=800,
+            on_navigate=on_navigate
+        )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description

From https://github.com/ihodev/a-file-icon/issues/64#issuecomment-272383883

Shows next popup right after first `Material Theme` installation and if `A File Icon` isn't installed:

```
Material Theme requires `A File Icon` package for enhanced
support of the file-specific icons.

Would you like to install it?
[Install] [Cancel]
```

#### How Has This Been Tested?

Install `Material Theme` on fresh Sublime Text.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
