### PR TITLE
Make the comments more visible and darker

### DIFF
--- a/schemes/Material-Theme-Lighter.tmTheme
+++ b/schemes/Material-Theme-Lighter.tmTheme
@@ -55,7 +55,7 @@
 				<key>fontStyle</key>
 				<string>italic</string>
 				<key>foreground</key>
-				<string>#CCD7DA</string>
+				<string>#A3ACAE</string>
 			</dict>
 		</dict>
 		<dict>

--- a/schemes/Material-Theme-Lighter.tmTheme
+++ b/schemes/Material-Theme-Lighter.tmTheme
@@ -55,7 +55,7 @@
 				<key>fontStyle</key>
 				<string>italic</string>
 				<key>foreground</key>
-				<string>#A3ACAE</string>
+				<string>#BDBDBD</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Reading the comments are harder with the lighter theme. This will darken the color and make it easy to read.

If you don't like the color, I'm really fine with any other color that is darker than the current one in the latest release.

I used the grey palette from here: https://material.io/guidelines/style/color.html#color-color-palette

**Before:**
![before](https://cloud.githubusercontent.com/assets/932717/23646419/6e09d134-0319-11e7-8622-fe1a3e8abff0.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/932717/23646429/771a47ea-0319-11e7-859d-83da4a7899bf.png)
