### PR TITLE
correct column headings in README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,19 +177,20 @@ Material Theme was also ported to:
 
 # Color Schemes palettes
 
-Color             | Default / Darker |  Lighter   |
----               | ---              |  ---       |
-Red               | `#FF5370`        |  `#E53935` |
-Pink              | `#f07178`        |  `#FF5370` |
-Orange            | `#F78C6C`        |  `#F76D47` |
-Yellow            | `#FFCB6B`        |  `#FFB62C` |
-Green             | `#C3E88D`        |  `#91B859` |
-Pale Blue         | `#B2CCD6`        |  `#8796B0` |
-Cyan              | `#89DDFF`        |  `#39ADB5` |
-Blue              | `#82AAFF`        |  `#6182B8` |
-Purple            | `#C792EA`        |  `#7C4DFF` |
-Violet            | `#bb80b3`        |  `#945EB8` |
-Brown             | `#ab7967`        |  `#ab7967` |
+Color      | Default / Lighter |  Darker    |
+---        | ---               |  ---       |
+Red        | `#FF5370`         |  `#E53935` |
+Pink       | `#F07178`         |  `#FF5370` |
+Orange     | `#F78C6C`         |  `#F76D47` |
+Yellow     | `#FFCB6B`         |  `#FFB62C` |
+Green      | `#C3E88D`         |  `#91B859` |
+Pale Blue  | `#B2CCD6`         |  `#8796B0` |
+Cyan       | `#89DDFF`         |  `#39ADB5` |
+Blue       | `#82AAFF`         |  `#6182B8` |
+Purple     | `#C792EA`         |  `#7C4DFF` |
+Violet     | `#BB80B3`         |  `#945EB8` |
+Brown      | `#AB7967`         |  `#AB7967` |
+
 
 
 


### PR DESCRIPTION
#### Description
Simply changed column headers in the color palette table.  

#### Motivation and Context
The darker colors were listed under "lighter" and vice versa.

#### How Has This Been Tested?
N/A

#### Screenshots (if appropriate):
N/A

#### Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ N/A ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
