### PR TITLE
Add title bar accent config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,44 +72,45 @@ If you want to enable the white panels and inputs you can install the addon pack
 
 ```json
 // Accent
-"material_theme_accent_acid-lime"         : true , // Set acid-lime accent color
-"material_theme_accent_blue"              : true , // Set blue accent color
-"material_theme_accent_brba"              : true , // Set Breaking Bad green accent color
-"material_theme_accent_bright-teal"       : true , // Set bright-teal accent color
-"material_theme_accent_cyan"              : true , // Set cyan accent color
-"material_theme_accent_graphite"          : true , // Set graphite accent color
-"material_theme_accent_indigo"            : true , // Set indigo accent color
-"material_theme_accent_lime"              : true , // Set lime green accent color
-"material_theme_accent_orange"            : true , // Set orange accent color
-"material_theme_accent_pink"              : true , // Set pink accent color
-"material_theme_accent_purple"            : true , // Set purple accent color
-"material_theme_accent_red"               : true , // Set pale red accent color
-"material_theme_accent_sky"               : true , // Set bright-cyan accent color
-"material_theme_accent_tomato"            : true , // Set tomato red accent color
-"material_theme_accent_yellow"            : true , // Set yellow accent color
+"material_theme_accent_acid-lime"         : true, // Set acid-lime accent color
+"material_theme_accent_blue"              : true, // Set blue accent color
+"material_theme_accent_brba"              : true, // Set Breaking Bad green accent color
+"material_theme_accent_bright-teal"       : true, // Set bright-teal accent color
+"material_theme_accent_cyan"              : true, // Set cyan accent color
+"material_theme_accent_graphite"          : true, // Set graphite accent color
+"material_theme_accent_indigo"            : true, // Set indigo accent color
+"material_theme_accent_lime"              : true, // Set lime green accent color
+"material_theme_accent_orange"            : true, // Set orange accent color
+"material_theme_accent_pink"              : true, // Set pink accent color
+"material_theme_accent_purple"            : true, // Set purple accent color
+"material_theme_accent_red"               : true, // Set pale red accent color
+"material_theme_accent_sky"               : true, // Set bright-cyan accent color
+"material_theme_accent_tomato"            : true, // Set tomato red accent color
+"material_theme_accent_yellow"            : true, // Set yellow accent color
 
 // Panels
-"material_theme_accent_scrollbars"        : true , // Enable accent color for scrollbars
-"material_theme_bright_scrollbars"        : true , // Bright scrollbars puck color
-"material_theme_compact_panel"            : true , // Set minimal padding for the search panel
-"material_theme_contrast_mode"            : true , // Enable sidebar and panels contrast mode
-"material_theme_panel_separator"          : true , // Show bottom panel separator
-"material_theme_small_statusbar"          : true , // Set small status bar
+"material_theme_accent_scrollbars"        : true, // Enable accent color for scrollbars
+"material_theme_accent_titlebar"          : true, // Enable accent color for title bar
+"material_theme_bright_scrollbars"        : true, // Bright scrollbars puck color
+"material_theme_compact_panel"            : true, // Set minimal padding for the search panel
+"material_theme_contrast_mode"            : true, // Enable sidebar and panels contrast mode
+"material_theme_panel_separator"          : true, // Show bottom panel separator
+"material_theme_small_statusbar"          : true, // Set small status bar
 
 // Sidebar
-"material_theme_arrow_folders"            : true , // Replace folder icons with arrows
-"material_theme_big_fileicons"            : true , // Show bigger file type icons
-"material_theme_bullet_tree_indicator"    : true , // Set a bullet as active tree indicator
-"material_theme_compact_sidebar"          : true , // Set compact side bar
-"material_theme_disable_fileicons"        : true , // Hide sidebar file type icons
-"material_theme_disable_folder_animation" : true , // Disable folder animation
-"material_theme_disable_tree_indicator"   : true , // Disable sidebar file indicator
+"material_theme_arrow_folders"            : true, // Replace folder icons with arrows
+"material_theme_big_fileicons"            : true, // Show bigger file type icons
+"material_theme_bullet_tree_indicator"    : true, // Set a bullet as active tree indicator
+"material_theme_compact_sidebar"          : true, // Set compact side bar
+"material_theme_disable_fileicons"        : true, // Hide sidebar file type icons
+"material_theme_disable_folder_animation" : true, // Disable folder animation
+"material_theme_disable_tree_indicator"   : true, // Disable sidebar file indicator
 
 // Tabs
-"material_theme_bold_tab"                 : true , // Make the tab labels bolder
-"material_theme_small_tab"                : true , // Set small tabs
-"material_theme_tabs_autowidth"           : true , // Enable autowidth for tabs
-"material_theme_tabs_separator"           : true , // Show tabs separator, this disables tab hover animation
+"material_theme_bold_tab"                 : true, // Make the tab labels bolder
+"material_theme_small_tab"                : true, // Set small tabs
+"material_theme_tabs_autowidth"           : true, // Enable autowidth for tabs
+"material_theme_tabs_separator"           : true, // Show tabs separator, this disables tab hover animation
 
 // If you use Material Theme - Appbar addon you can use additional settings:
 "material_theme_tree_headings"            : true , // Show sidebar headings
@@ -120,8 +121,8 @@ If you want to enable the white panels and inputs you can install the addon pack
 ```json
 "always_show_minimap_viewport" : true,
 "bold_folder_labels"           : true,
-"font_options"                 : [ "gray_antialias", "subpixel_antialias" ],    // On retina Mac & Windows
-"indent_guide_options"         : [ "draw_normal", "draw_active" ],   // Highlight active indent
+"font_options"                 : ["gray_antialias", "subpixel_antialias"], // On retina Mac & Windows
+"indent_guide_options"         : ["draw_normal", "draw_active"], // Highlight active indent
 "line_padding_bottom"          : 3,
 "line_padding_top"             : 3,
 "overlay_scroll_bars"          : "enabled",
@@ -156,7 +157,7 @@ You can now edit the source files under `./sources` folder that will be compiled
 
 **App icon**: [Download](https://github.com/equinusocio/material-theme/files/396220/Material-Theme-Icon.zip) the official Material Theme icon.
 
-**Sublime Material Icon Pack**: A set of Sublime Text icons heavily inspired by this theme and designed by @halacoglu 
+**Sublime Material Icon Pack**: A set of Sublime Text icons heavily inspired by this theme and designed by @halacoglu
 [Download ](https://github.com/halacoglu/sublime-material-icon-pack) it and enjoy a full Material Theme experience.
 
 # Official Portings

--- a/sources/themes/commons/accent.json
+++ b/sources/themes/commons/accent.json
@@ -399,6 +399,15 @@
     "layer1.opacity": 0.8
   },
 
+    // Title Bar
+
+  {
+    "class": "title_bar",
+    "settings": ["material_theme_accent_titlebar", "material_theme_accent_<%= ui.accents[i].id %>"],
+    "bg": [<%= ui.accents[i].rgb %>],
+    "fg": [<%= ui.accents[i].foreground.rgb %>]
+  },
+
   // Symlink folder icon
 
   {

--- a/utils/config.py
+++ b/utils/config.py
@@ -61,7 +61,8 @@ OPTIONS = OrderedDict(
             'material_theme_panel_separator',
             'material_theme_contrast_mode',
             'material_theme_bright_scrollbars',
-            'material_theme_accent_scrollbars'
+            'material_theme_accent_scrollbars',
+            'material_theme_accent_titlebar'
           ],
         )
     )


### PR DESCRIPTION
#### Description
<!-- Describe your changes in detail -->
I created a new setting “material_theme_accent_titlebar” to colorize the title bar via chosen accent color (background and foreground).  Also added it to the README file and removed some extra spaces in the settings.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This would provide the ability to change the title bar color, so it matches the accent used throughout the theme.  This would also work with the App Bar to mix or match accents (see issue on missing colors https://github.com/equinusocio/material-theme-appbar/issues/52).

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
The setting was tested using PackageDev, NPM, and Gulp to compile and view the modified theme.  The README file was tested using dillinger.io markdown editor.

#### Screenshots (if appropriate):
![demo](https://user-images.githubusercontent.com/11165740/30882268-6c7eedb0-a2d6-11e7-9896-273bedbc8d93.gif)

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.