### PR TITLE
Fix theme not activating after installation

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -2,10 +2,12 @@
   "*": {
     ">=3114": [
       "markupsafe",
-      "python-jinja2",
       "mdpopups",
+      "pygments",
+      "pymdownx",
+      "python-jinja2",
       "python-markdown",
-      "pygments"
+      "pyyaml"
     ]
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Updated the dependencies JSON file to add missing dependencies required by the latest version of mdpopups.  

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This fixes the issue not enabling theme activation after installation, which many users have experienced using the latest version of Sublime. 
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/equinusocio/material-theme/issues/1229

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
This was tested by removing the theme's dependencies in the Packages folder, which disabled theme activation and other options in the Preferences -> Package Settings -> Material Theme menu, except the advanced configuration option.  Then, I restarted Sublime a few times and Package Control installed those dependencies automatically.  This enabled the greyed out menu options as a result. 

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
